### PR TITLE
Correct spurious prepend of labels

### DIFF
--- a/tikz-network.sty
+++ b/tikz-network.sty
@@ -538,7 +538,8 @@
     % Define local style for the label
     \tikzset{LocalLabel/.style={label = {[LabelStyle, LocalVertexFontColor,
           LocalVertexFontSize, LocalVertexFontScale, label
-          distance=\cmdNW@vertex@distance]\cmdNW@vertex@position:\vertex@Label}}}
+          distance=\cmdNW@vertex@distance, label
+          position=\cmdNW@vertex@position]\vertex@Label}}}
     \ifthenelse{\equal{\cmdNW@vertex@layer}{}}{
       \protected@edef\@tempa{%
         \noexpand\node[\vstyle,LocalVertexSize,LocalVertexOpacity,LocalVertexFill,LocalVertexShape,LocalLabel,\cmdNW@vertex@style,LocalPseudo](#1)%


### PR DESCRIPTION
Hello Hr. Hackl,

First of all, thank you very much for this very useful package.

I have recently stumbled upon the issue mentioned in #6.

As M. Chareyron [mentioned](https://github.com/hackl/tikz-network/issues/6#issuecomment-989913162), the bug is reproducible only with french babel.

Indeed, when using the example you provided, namely : 
```latex
\documentclass{standalone}
\usepackage{tikz-network}
\begin{document}
\begin{tikzpicture}
  \Vertex[position=above,label=a]{A}
  \Vertex[x=1,y=.7,position=below,label=b]{B}
  \Vertex[x=2,y=1,position=left,label=c]{C}
  \Vertex[x=2,position=right,label=d]{D}
  \Vertex[x=.2,y=1.5,position=75,label=e]{E}
\end{tikzpicture}
\end{document}
```
One gets the following, correct, result : 

![correct](https://github.com/user-attachments/assets/90e8478d-551c-4928-8670-6fe10b66ac37)

However, when one includes babel, like so : 
```latex
\documentclass{standalone}
\usepackage{tikz-network}
\PassOptionsToPackage{french}{babel}
\usepackage{babel}
\begin{document}
\begin{tikzpicture}
  \Vertex[position=above,label=a]{A}
  \Vertex[x=1,y=.7,position=below,label=b]{B}
  \Vertex[x=2,y=1,position=left,label=c]{C}
  \Vertex[x=2,position=right,label=d]{D}
  \Vertex[x=.2,y=1.5,position=75,label=e]{E}
\end{tikzpicture}
\end{document}
```

One gets this : 

![incorrect](https://github.com/user-attachments/assets/4ec1850f-d201-47d4-af3f-a6e06e7b0f57)

I am not sure how tikz-network and babel interfere with each other. It is possibly due to how french babel treats cola. For this reason, the PR proposes to simply ditch the `{position:label}` syntax you use, and replace it with the equivalent and more robust `{[label position = position]label}`.

Applying the patch solves the issue on the example I provided, and I do not think it would break anything.

Thank you very much in advance.

Mit freundlichen Grüßen,

Aymeric

P.S. If you do indeed merge this, would you be so kind as to tag a new release, so that it gets distributed ?